### PR TITLE
Add ros-melodic-tf2-geometry-msgs install to Dockerfile for build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -109,6 +109,7 @@ RUN apt update && apt install --no-install-recommends -y \
     ros-melodic-compressed-image-transport\
     ros-melodic-audio-common-msgs \
     ros-melodic-usb-cam \
+    ros-melodic-tf2-geometry-msgs \
     && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
 WORKDIR ${WORKSPACE}


### PR DESCRIPTION
I added the installation of 'ros-melodic-tf2-geometry-msgs' to the Dockerfile because I encountered an error below, specifically 'pr1040n', which prevented the build process.  
```bash
_______________________________________________________________________________
Errors << azure_kinect_ros_driver:cmake /catkin_ws/logs/azure_kinect_ros_driver/build.cmake.000.log
CMake Error at /opt/ros/melodic/share/catkin/cmake/catkinConfig.cmake:83 (find_package):
  Could not find a package configuration file provided by "tf2_geometry_msgs"
  with any of the following names:

    tf2_geometry_msgsConfig.cmake
    tf2_geometry_msgs-config.cmake

  Add the installation prefix of "tf2_geometry_msgs" to CMAKE_PREFIX_PATH or
  set "tf2_geometry_msgs_DIR" to a directory containing one of the above
  files.  If "tf2_geometry_msgs" provides a separate development package or
  SDK, be sure it has been installed.
Call Stack (most recent call first):
  CMakeLists.txt:14 (find_package)


cd /catkin_ws/build/azure_kinect_ros_driver; catkin build --get-env azure_kinect_ros_driver | catkin env -si  /usr/bin/cmake /catkin_ws/src/Azure_Kinect_ROS_Driver --no-warn-unused-cli -DCATKIN_DEVEL_PREFIX=/catkin_ws/devel/.private/azure_kinect_ros_driver -DCMAKE_INSTALL_PREFIX=/catkin_ws/install -DCMAKE_BUILD_TYPE=Release; cd -
...............................................................................
Failed << azure_kinect_ros_driver:cmake           [ Exited with code 1 ]       
```